### PR TITLE
Remove obsolete parameter in example code

### DIFF
--- a/docs/rigid_body_simulations_with_contacts.md
+++ b/docs/rigid_body_simulations_with_contacts.md
@@ -547,7 +547,7 @@ Every collider must be attached to a body part by specifying the body part handl
 
 ```rust
 let parent_rigid_body = RigidBodyDesc::new()
-    .build(&mut world);
+    .build();
 let parent_handle = body_set.insert(parent_rigid_body);
 
 let shape = ShapeHandle::new(Ball::new(1.5));


### PR DESCRIPTION
Seems to be a remnant from the last version, right?